### PR TITLE
Fix port docs

### DIFF
--- a/docker_compose/README.md
+++ b/docker_compose/README.md
@@ -2,11 +2,12 @@
 
 ```sh
 curl -i http://127.0.0.1:8080/
-curl -i http://127.0.0.1:8080/ -d "{\"description\":\"message $RANDOM\", \"completed\":false}" -H 'Content-Type: application/spkane.todo-list.v1+json'
-curl -i http://127.0.0.1:8080/ -d "{\"description\":\"message $RANDOM\",\"completed\":false}" -H 'Content-Type: application/spkane.todo-list.v1+json'
-curl -i http://127.0.0.1:8080/ -d "{\"description\":\"message $RANDOM\",\"completed\":false}" -H 'Content-Type: application/spkane.todo-list.v1+json'
-curl -i http://127.0.0.1:8080/3 -X PUT -H 'Content-Type: application/spkane.todo-list.v1+json' -d '{"description":"go shopping",\"completed\":true}'
-curl -i http://127.0.0.1:8080/1 -X DELETE -H 'Content-Type: application/spkane.todo-list.v1+json'
-curl -i http://127.0.0.1:8080/3 -X DELETE -H 'Content-Type: application/spkane.todo-list.v1+json'
+curl -i http://127.0.0.1:8080/ -X POST -H 'Content-Type: application/spkane.todo-list.v1+json' -d "{\"description\":\"message $RANDOM\", \"completed\":false}"
+curl -i http://127.0.0.1:8080/ -X POST -H 'Content-Type: application/spkane.todo-list.v1+json' -d "{\"description\":\"message $RANDOM\",\"completed\":false}"
+curl -i http://127.0.0.1:8080/ -X POST -H 'Content-Type: application/spkane.todo-list.v1+json' -d "{\"description\":\"message $RANDOM\",\"completed\":false}"
+curl -i http://127.0.0.1:8080/3 -X PUT -H 'Content-Type: application/spkane.todo-list.v1+json' -d '{"description":"go shopping","completed":true}'
+curl -i http://127.0.0.1:8080/1 -X DELETE
+curl -i http://127.0.0.1:8080/3 -X DELETE
 curl -i http://127.0.0.1:8080
+curl -i http://127.0.0.1:8080/2 -X DELETE
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Use the navigation to the left to read about the available resources.
 # Configure the connection details for the Todo API server
 provider "todo" {
   host    = "127.0.0.1"
-  port    = 8080
+  port    = "8080"
   schema  = "http"
   apipath = "/"
 }
@@ -43,7 +43,7 @@ data "todo_todo" "example" {
 
 ### Optional
 
-- `apipath` (String) The URL path for the Todo server API (e.g. /). May also be provided via TODO_APIPATH environment variable.
-- `host` (String) The FQDN or IP address for the Todo server (e.g. 127.0.0.1). May also be provided via TODO_HOST environment variable.
-- `port` (String) The port for the Todo server (e.g. 8080). May also be provided via TODO_PORT environment variable.
-- `schema` (String) The URL schema for the Todo server (e.g. http). May also be provided via TODO_SCHEMA environment variable.
+- `apipath` (String) The URL path for the Todo server API (e.g. '/'). May also be provided via TODO_APIPATH environment variable.
+- `host` (String) The FQDN or IP address for the Todo server (e.g. '127.0.0.1'). May also be provided via TODO_HOST environment variable.
+- `port` (String) The port for the Todo server (e.g. '8080'). May also be provided via TODO_PORT environment variable.
+- `schema` (String) The URL schema for the Todo server (e.g. 'http'). May also be provided via TODO_SCHEMA environment variable.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 # Configure the connection details for the Todo API server
 provider "todo" {
   host    = "127.0.0.1"
-  port    = 8080
+  port    = "8080"
   schema  = "http"
   apipath = "/"
 }

--- a/todo/provider.go
+++ b/todo/provider.go
@@ -53,19 +53,19 @@ func (p *todoProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp 
 		Attributes: map[string]schema.Attribute{
 			"host": schema.StringAttribute{
 				Optional:    true,
-				Description: "The FQDN or IP address for the Todo server (e.g. 127.0.0.1). May also be provided via TODO_HOST environment variable.",
+				Description: "The FQDN or IP address for the Todo server (e.g. '127.0.0.1'). May also be provided via TODO_HOST environment variable.",
 			},
 			"port": schema.StringAttribute{
 				Optional:    true,
-				Description: "The port for the Todo server (e.g. 8080). May also be provided via TODO_PORT environment variable.",
+				Description: "The port for the Todo server (e.g. '8080'). May also be provided via TODO_PORT environment variable.",
 			},
 			"schema": schema.StringAttribute{
 				Optional:    true,
-				Description: "The URL schema for the Todo server (e.g. http). May also be provided via TODO_SCHEMA environment variable.",
+				Description: "The URL schema for the Todo server (e.g. 'http'). May also be provided via TODO_SCHEMA environment variable.",
 			},
 			"apipath": schema.StringAttribute{
 				Optional:    true,
-				Description: "The URL path for the Todo server API (e.g. /). May also be provided via TODO_APIPATH environment variable.",
+				Description: "The URL path for the Todo server API (e.g. '/'). May also be provided via TODO_APIPATH environment variable.",
 			},
 		},
 		Blocks:      map[string]schema.Block{},
@@ -171,7 +171,7 @@ func (p *todoProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	if port == "" {
 		resp.Diagnostics.AddAttributeWarning(
 			path.Root("port"),
-			"Missing Todo API port (using default value: 8080)",
+			"Missing Todo API port (using default value: '8080')",
 			"The provider is using a default value as there is a missing or empty value for the Todo API port. "+
 				"Set the port value in the configuration or use the TODO_PORT environment variable. "+
 				"If either is already set, ensure the value is not empty.",

--- a/todo/provider_test.go
+++ b/todo/provider_test.go
@@ -13,7 +13,7 @@ const (
 	providerConfig = `
 provider "todo" {
   host    = "127.0.0.1"
-  port    = 8080
+  port    = "8080"
   schema  = "http"
   apipath = "/"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated usage examples for the Todo API to clarify HTTP methods for creating and deleting todo items.
	- Changed the data type of the `port` attribute in documentation from integer to string for consistency.
	- Enhanced attribute descriptions in the provider schema to improve clarity by adding single quotes around example values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->